### PR TITLE
feat: add max-summary-length input

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Options are specified on the [`with` map](https://docs.github.com/en/actions/usi
 * **`run-url`: URL to the workflow run where the tests were executed** (optional)
   It will be linked to the title of the produced test summary.
 
+* **`max-summary-length`: Maximum length (in characters) allowed for the generated summary.** (optional)
+  If exceeded, the summary will be truncated. Details sections will be removed first, and if the length is still greater than the limit, tests will be removed iteratively from the end until the summary meets the specified maximum length.
 
 FAQ
 ---

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   flaky-tests-json:
     description: Path to the JSON file with flaky test information to flag them in the summary.
     required: false
+  max-summary-length:
+    description: Maximum length of the summary section. Longer summaries will have the details section removed if necessary or be truncated if still too long.
+    default: 65534
+    required: false
 
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,7 +21,7 @@ const flakyIconUrl = "https://github.com/tomtom-forks/test-summary-action/raw/ic
 // not used: const noneIconUrl = '"https://github.com/tomtom-forks/test-summary-action/raw/icons/assets/none.svg'
 const unnamedTestCase = "<no name>";
 const footer = `This test report was produced by the <a href="https://github.com/test-summary/action">test-summary action</a>.&nbsp; Made with ❤️ in Cambridge.`;
-function dashboardSummary(result, show, summaryTitleInput, runUrl) {
+function dashboardSummary(result, show, summaryTitleInput, runUrl, maxLength) {
     const count = result.counts;
     let summary = "";
     if (count.passed > 0) {
@@ -37,10 +37,14 @@ function dashboardSummary(result, show, summaryTitleInput, runUrl) {
     const summaryTitleHtml = runUrl
         ? `<h2><a href="${runUrl}" target="_blank">${summaryTitle}</a></h2>`
         : `<h2>${summaryTitle}</h2>`;
-    return `${summaryTitleHtml}<img src="${dashboardUrl}?p=${count.passed}&f=${count.failed}&s=${count.skipped}" alt="${summary}">`;
+    const finalSummary = `${summaryTitleHtml}<img src="${dashboardUrl}?p=${count.passed}&f=${count.failed}&s=${count.skipped}" alt="${summary}">`;
+    if (maxLength && finalSummary.length > maxLength) {
+        throw new Error("Summary length exceeds maximum length, this part cannot be truncated. Please consider increasing max-summary-length input");
+    }
+    return finalSummary;
 }
 exports.dashboardSummary = dashboardSummary;
-function dashboardResults(result, show, flakyTestsInfo = false) {
+function dashboardResults(result, show, flakyTestsInfo = false, maxLength = undefined, currentLength = 0) {
     let results = ``;
     let count = 0;
     for (const suite of result.suites) {
@@ -110,6 +114,30 @@ function dashboardResults(result, show, flakyTestsInfo = false) {
         return `<h3>No test results to display.</h3>
       If the pipeline failed but no test runs indicate failures, it might be due to a 
       <strong>build failure</strong> or a <strong>timeout</strong>. Check the logs for more information.`;
+    }
+    const summaryTruncatedNote = `<p><b>⚠️ Results truncated due to length constraints.</b></p>`;
+    if (maxLength && currentLength + results.length > maxLength) {
+        let resultsTruncated = results.replace(/<details>[\s\S]*?<\/details>/g, "");
+        if (resultsTruncated.length + currentLength <= maxLength) {
+            return resultsTruncated;
+        }
+        // Iteratively remove the last <tr><td>...</td></tr>
+        while (currentLength +
+            resultsTruncated.length +
+            summaryTruncatedNote.length >
+            maxLength) {
+            const lastRowMatch = resultsTruncated.match(/<tr><td>[\s\S]*?<\/td><\/tr>/g);
+            if (lastRowMatch && lastRowMatch.length > 0) {
+                // Remove the last match
+                resultsTruncated = resultsTruncated
+                    .replace(lastRowMatch[lastRowMatch.length - 1], "")
+                    .replace(/<table>\s*(<tr>\s*<th[^>]*>[^<]*<\/th>\s*<\/tr>\s*)?<\/table>/g, ""); // Remove empty tables
+            }
+            else {
+                break;
+            }
+        }
+        return (resultsTruncated += summaryTruncatedNote);
     }
     return results;
 }
@@ -358,6 +386,7 @@ function run() {
             const summaryTitle = core.getInput("summary-title") || "";
             const flakyTestsJsonPath = core.getInput("flaky-tests-json") || "";
             const runUrl = core.getInput("run-url") || "";
+            const maxSummaryLength = parseInt(core.getInput("max-summary-length")) || undefined;
             /*
              * Given paths may either be an individual path (eg "foo.xml"),
              * a path glob (eg "**TEST-*.xml"), or may be newline separated
@@ -418,9 +447,10 @@ function run() {
             if (flakyTestsJsonPath) {
                 total = (0, flaky_tests_1.markFlakyTests)(total, flakyTestsJsonPath);
             }
-            let output = (0, dashboard_1.dashboardSummary)(total, show, summaryTitle, runUrl);
+            let output = (0, dashboard_1.dashboardSummary)(total, show, summaryTitle, runUrl, maxSummaryLength);
+            const current_length = output.length;
             if (show) {
-                output += (0, dashboard_1.dashboardResults)(total, show, flakyTestsJsonPath !== "");
+                output += (0, dashboard_1.dashboardResults)(total, show, flakyTestsJsonPath !== "", maxSummaryLength, current_length);
             }
             if (outputFile === "-") {
                 core.info(output);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -20,7 +20,8 @@ export function dashboardSummary(
     result: TestResult,
     show: number,
     summaryTitleInput: string,
-    runUrl: string
+    runUrl: string,
+    maxLength: number | undefined
 ): string {
     const count = result.counts
     let summary = ""
@@ -41,13 +42,23 @@ export function dashboardSummary(
         ? `<h2><a href="${runUrl}" target="_blank">${summaryTitle}</a></h2>`
         : `<h2>${summaryTitle}</h2>`
 
-    return `${summaryTitleHtml}<img src="${dashboardUrl}?p=${count.passed}&f=${count.failed}&s=${count.skipped}" alt="${summary}">`
+    const finalSummary = `${summaryTitleHtml}<img src="${dashboardUrl}?p=${count.passed}&f=${count.failed}&s=${count.skipped}" alt="${summary}">`
+
+    if (maxLength && finalSummary.length > maxLength) {
+        throw new Error(
+            "Summary length exceeds maximum length, this part cannot be truncated. Please consider increasing max-summary-length input"
+        )
+    }
+
+    return finalSummary
 }
 
 export function dashboardResults(
     result: TestResult,
     show: number,
-    flakyTestsInfo = false
+    flakyTestsInfo = false,
+    maxLength: number | undefined = undefined,
+    currentLength = 0
 ): string {
     let results = ``
     let count = 0
@@ -139,6 +150,43 @@ export function dashboardResults(
         return `<h3>No test results to display.</h3>
       If the pipeline failed but no test runs indicate failures, it might be due to a 
       <strong>build failure</strong> or a <strong>timeout</strong>. Check the logs for more information.`
+    }
+
+    const summaryTruncatedNote = `<p><b>⚠️ Results truncated due to length constraints.</b></p>`
+
+    if (maxLength && currentLength + results.length > maxLength) {
+        let resultsTruncated = results.replace(
+            /<details>[\s\S]*?<\/details>/g,
+            ""
+        )
+        if (resultsTruncated.length + currentLength <= maxLength) {
+            return resultsTruncated
+        }
+
+        // Iteratively remove the last <tr><td>...</td></tr>
+        while (
+            currentLength +
+                resultsTruncated.length +
+                summaryTruncatedNote.length >
+            maxLength
+        ) {
+            const lastRowMatch = resultsTruncated.match(
+                /<tr><td>[\s\S]*?<\/td><\/tr>/g
+            )
+            if (lastRowMatch && lastRowMatch.length > 0) {
+                // Remove the last match
+                resultsTruncated = resultsTruncated
+                    .replace(lastRowMatch[lastRowMatch.length - 1], "")
+                    .replace(
+                        /<table>\s*(<tr>\s*<th[^>]*>[^<]*<\/th>\s*<\/tr>\s*)?<\/table>/g,
+                        ""
+                    ) // Remove empty tables
+            } else {
+                break
+            }
+        }
+
+        return (resultsTruncated += summaryTruncatedNote)
     }
 
     return results

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,8 @@ async function run(): Promise<void> {
         const summaryTitle = core.getInput("summary-title") || ""
         const flakyTestsJsonPath = core.getInput("flaky-tests-json") || ""
         const runUrl = core.getInput("run-url") || ""
+        const maxSummaryLength =
+            parseInt(core.getInput("max-summary-length")) || undefined
 
         /*
          * Given paths may either be an individual path (eg "foo.xml"),
@@ -196,10 +198,23 @@ async function run(): Promise<void> {
             total = markFlakyTests(total, flakyTestsJsonPath)
         }
 
-        let output = dashboardSummary(total, show, summaryTitle, runUrl)
+        let output = dashboardSummary(
+            total,
+            show,
+            summaryTitle,
+            runUrl,
+            maxSummaryLength
+        )
+        const current_length = output.length
 
         if (show) {
-            output += dashboardResults(total, show, flakyTestsJsonPath !== "")
+            output += dashboardResults(
+                total,
+                show,
+                flakyTestsJsonPath !== "",
+                maxSummaryLength,
+                current_length
+            )
         }
 
         if (outputFile === "-") {

--- a/test/dashboard.ts
+++ b/test/dashboard.ts
@@ -145,4 +145,154 @@ describe("dashboard", async () => {
         )
         expect(count).to.equal(2) // Once comes from the footer
     })
+    it("removes details sections to adjust to maxLength", async () => {
+        const result: TestResult = {
+            counts: { passed: 0, failed: 1, skipped: 0 },
+            suites: [
+                {
+                    name: "TestSuite1",
+                    project: "testsuite-project-name",
+                    cases: [
+                        {
+                            status: TestStatus.Fail,
+                            name: "test1",
+                            description: "test",
+                            message: "expected:<99> but was:<98>",
+                            details:
+                                "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                                "\tat test.failsTestSix(Unknown Source)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                            duration: "0.005",
+                            flaky: true,
+                            flakyTestTicket:
+                                "https://jira.example.com/browse/TEST-1",
+                            run_count: 1,
+                            fail_count: 1
+                        },
+                        {
+                            status: TestStatus.Fail,
+                            name: "test2",
+                            description: "test",
+                            message: "expected:<99> but was:<98>",
+                            details:
+                                "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                                "\tat test.failsTestFive(Unknown Source)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                            duration: "0.005",
+                            run_count: 1,
+                            fail_count: 1
+                        }
+                    ]
+                }
+            ]
+        }
+        let actual = dashboardResults(result, TestStatus.Fail, true, 5000, 0)
+        expect(actual).not.contains(`<details>`)
+    })
+
+    it("removes details and last test with its table to adjust to maxLength", async () => {
+        const result: TestResult = {
+            counts: { passed: 0, failed: 1, skipped: 0 },
+            suites: [
+                {
+                    name: "TestSuite1",
+                    project: "testsuite-project-name",
+                    cases: [
+                        {
+                            status: TestStatus.Fail,
+                            name: "test1",
+                            description: "test",
+                            message: "expected:<99> but was:<98>",
+                            details:
+                                "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                                "\tat test.failsTestSix(Unknown Source)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                            duration: "0.005",
+                            flaky: true,
+                            flakyTestTicket:
+                                "https://jira.example.com/browse/TEST-1",
+                            run_count: 1,
+                            fail_count: 1
+                        }
+                    ]
+                },
+                {
+                    name: "TestSuite2",
+                    project: "testsuite-project-name",
+                    cases: [
+                        {
+                            status: TestStatus.Fail,
+                            name: "test2",
+                            description: "test",
+                            message: "expected:<99> but was:<98>",
+                            details:
+                                "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                                "\tat test.failsTestFive(Unknown Source)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                                "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                                "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                            duration: "0.005",
+                            run_count: 1,
+                            fail_count: 1
+                        }
+                    ]
+                }
+            ]
+        }
+        let actual = dashboardResults(result, TestStatus.Fail, true, 900, 0)
+        const count = (actual.match(/\<table\>/g) || []).length
+        expect(count).to.equal(1) // Only one table should remain
+        expect(actual).not.contains(`test2`)
+    })
 })


### PR DESCRIPTION
Add max-summary-length optional input.
If exceeded, the summary will be truncated. Details sections will be removed first, and if the length is still greater than the limit, tests will be removed iteratively from the end until the summary meets the specified maximum length.