### PR TITLE
feat: add system-error testcase parsing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -69,11 +69,14 @@ function dashboardResults(result, show, flakyTestsInfo = false, maxLength = unde
             }
             if (flakyTestsInfo && testcase.flaky) {
                 if (testcase.flakyTestTicket) {
-                    table += `<a href="${testcase.flakyTestTicket}" target="_blank">[FLAKY] </a> `;
+                    table += `<a href="${testcase.flakyTestTicket}" target="_blank">[FLAKY]</a> `;
                 }
                 else {
-                    table += "[FLAKY] ";
+                    table += "[FLAKY]";
                 }
+            }
+            if (testcase.system_error) {
+                table += "[CRASH] ";
             }
             table += (0, escape_html_1.default)(testcase.name || unnamedTestCase);
             if (testcase.description) {
@@ -661,7 +664,8 @@ function parseTap(data) {
                 run_count: 0,
                 fail_count: 0,
                 flaky: false,
-                flakyTestTicket: undefined // This will be set later if flaky tests are marked
+                flakyTestTicket: undefined,
+                system_error: false
             });
         }
         suites.push({
@@ -714,6 +718,7 @@ function parseJunitXml(xml) {
             }
             for (const testcase of testsuite.testcase) {
                 let status = TestStatus.Pass;
+                let system_error = false;
                 const classname = testcase.$.classname;
                 const name = testcase.$.name;
                 const duration = testcase.$.time;
@@ -724,7 +729,10 @@ function parseJunitXml(xml) {
                     status = TestStatus.Skip;
                     counts.skipped++;
                 }
-                else if ((failure_or_error = testcase.failure || testcase.error)) {
+                else if ((failure_or_error =
+                    testcase.failure ||
+                        testcase.error ||
+                        testcase["system-error"])) {
                     status = TestStatus.Fail;
                     const element = failure_or_error[0];
                     message = element.$ ? element.$.message : undefined;
@@ -735,6 +743,7 @@ function parseJunitXml(xml) {
                         details = element._;
                     }
                     counts.failed++;
+                    system_error = testcase["system-error"] ? true : false;
                 }
                 else {
                     counts.passed++;
@@ -749,7 +758,8 @@ function parseJunitXml(xml) {
                     run_count: 0,
                     fail_count: 0,
                     flaky: false,
-                    flakyTestTicket: undefined // This will be set later if flaky tests are marked
+                    flakyTestTicket: undefined,
+                    system_error
                 });
             }
             suites.push({

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -91,10 +91,13 @@ export function dashboardResults(
 
             if (flakyTestsInfo && testcase.flaky) {
                 if (testcase.flakyTestTicket) {
-                    table += `<a href="${testcase.flakyTestTicket}" target="_blank">[FLAKY] </a> `
+                    table += `<a href="${testcase.flakyTestTicket}" target="_blank">[FLAKY]</a> `
                 } else {
-                    table += "[FLAKY] "
+                    table += "[FLAKY]"
                 }
+            }
+            if (testcase.system_error) {
+                table += "[CRASH] "
             }
             table += escapeHTML(testcase.name || unnamedTestCase)
 

--- a/src/test_parser.ts
+++ b/src/test_parser.ts
@@ -42,6 +42,7 @@ export interface TestCase {
     fail_count?: number
     flaky?: boolean
     flakyTestTicket?: string
+    system_error?: boolean
 }
 
 export async function parseTap(data: string): Promise<TestResult> {
@@ -200,7 +201,8 @@ export async function parseTap(data: string): Promise<TestResult> {
             run_count: 0,
             fail_count: 0,
             flaky: false, // Flaky tests will be marked later
-            flakyTestTicket: undefined // This will be set later if flaky tests are marked
+            flakyTestTicket: undefined, // This will be set later if flaky tests are marked
+            system_error: false
         })
     }
 
@@ -256,6 +258,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
 
         for (const testcase of testsuite.testcase) {
             let status = TestStatus.Pass
+            let system_error = false
 
             const classname = testcase.$.classname
             const name = testcase.$.name
@@ -270,7 +273,10 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
 
                 counts.skipped++
             } else if (
-                (failure_or_error = testcase.failure || testcase.error)
+                (failure_or_error =
+                    testcase.failure ||
+                    testcase.error ||
+                    testcase["system-error"])
             ) {
                 status = TestStatus.Fail
 
@@ -284,6 +290,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
                 }
 
                 counts.failed++
+                system_error = testcase["system-error"] ? true : false
             } else {
                 counts.passed++
             }
@@ -298,7 +305,8 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
                 run_count: 0,
                 fail_count: 0,
                 flaky: false, // Flaky tests will be marked later
-                flakyTestTicket: undefined // This will be set later if flaky tests are marked
+                flakyTestTicket: undefined, // This will be set later if flaky tests are marked
+                system_error
             })
         }
 

--- a/test/dashboard.ts
+++ b/test/dashboard.ts
@@ -141,10 +141,11 @@ describe("dashboard", async () => {
         let actual = dashboardResults(result, TestStatus.Fail, true)
         const count = (actual.match(/\[FLAKY\]/g) || []).length
         expect(actual).contains(
-            `<a href="https://jira.example.com/browse/TEST-1" target="_blank">[FLAKY] </a> `
+            `<a href="https://jira.example.com/browse/TEST-1" target="_blank">[FLAKY]</a> `
         )
         expect(count).to.equal(2) // Once comes from the footer
     })
+
     it("removes details sections to adjust to maxLength", async () => {
         const result: TestResult = {
             counts: { passed: 0, failed: 1, skipped: 0 },
@@ -295,4 +296,60 @@ describe("dashboard", async () => {
         expect(count).to.equal(1) // Only one table should remain
         expect(actual).not.contains(`test2`)
     })
+      it("includes system error", async () => {
+      const result: TestResult = {
+          counts: { passed: 0, failed: 1, skipped: 0 },
+          suites: [
+              {
+                  name: "TestSuite1",
+                  project: "testsuite-project-name",
+                  cases: [
+                      {
+                          status: TestStatus.Fail,
+                          name: "test1",
+                          description: "test",
+                          message: "expected:<99> but was:<98>",
+                          details:
+                              "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                              "\tat test.failsTestSix(Unknown Source)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                              "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                              "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                          duration: "0.005",
+                          flaky: true,
+                          flakyTestTicket:
+                              "https://jira.example.com/browse/TEST-1",
+                          run_count: 1,
+                          fail_count: 1
+                      },
+                      {
+                          status: TestStatus.Fail,
+                          name: "test2",
+                          description: "test",
+                          message: "expected:<99> but was:<98>",
+                          details:
+                              "junit.framework.AssertionFailedError: expected:<99> but was:<98>\n" +
+                              "\tat test.failsTestFive(Unknown Source)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                              "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+                              "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+                              "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n",
+                          duration: "0.005",
+                          run_count: 1,
+                          fail_count: 1,
+                          system_error: true
+                      }
+                  ]
+              }
+          ]
+      }
+      let actual = dashboardResults(result, TestStatus.Fail, true)
+      expect(actual).contains(`[CRASH]`)
+  })
+
 })

--- a/test/file.ts
+++ b/test/file.ts
@@ -56,7 +56,7 @@ describe("file", async () => {
     it("identifies junit", async () => {
         const result = await parseFile(`${junitResourcePath}/03-junit.xml`)
         expect(result.counts.passed).to.eql(4)
-        expect(result.counts.failed).to.eql(4)
+        expect(result.counts.failed).to.eql(5)
         expect(result.counts.skipped).to.eql(2)
     })
 })

--- a/test/junit.ts
+++ b/test/junit.ts
@@ -96,7 +96,7 @@ describe("junit", async () => {
         const result = await parseJunitFile(`${resourcePath}/03-junit.xml`)
 
         expect(result.counts.passed).to.eql(4)
-        expect(result.counts.failed).to.eql(4)
+        expect(result.counts.failed).to.eql(5)
         expect(result.counts.skipped).to.eql(2)
 
         expect(result.suites.length).to.eql(1)
@@ -210,13 +210,19 @@ describe("junit", async () => {
         expect(resultUpdated.suites[0].cases[5].flaky).to.eql(false)
         expect(resultUpdated.suites[0].cases[6].flaky).to.eql(false)
         expect(resultUpdated.suites[0].cases[7].flaky).to.eql(false)
-        expect(resultUpdated.suites[0].cases[8].flaky).to.eql(true)
-        expect(resultUpdated.suites[0].cases[8].flakyTestTicket).to.eql(
-            "https://jira.example.com/browse/TEST-1"
-        )
+        expect(resultUpdated.suites[0].cases[8].flaky).to.eql(false)
         expect(resultUpdated.suites[0].cases[9].flaky).to.eql(true)
         expect(resultUpdated.suites[0].cases[9].flakyTestTicket).to.eql(
+            "https://jira.example.com/browse/TEST-1"
+        )
+        expect(resultUpdated.suites[0].cases[10].flaky).to.eql(true)
+        expect(resultUpdated.suites[0].cases[10].flakyTestTicket).to.eql(
             undefined
         )
+    })
+    it("identifies system error tests", async () => {
+        const result = await parseJunitFile(`${resourcePath}/03-junit.xml`)
+        expect(result.suites[0].cases[9].system_error).to.eql(false)
+        expect(result.suites[0].cases[10].system_error).to.eql(true)
     })
 })

--- a/test/resources/junit/03-junit.xml
+++ b/test/resources/junit/03-junit.xml
@@ -121,6 +121,17 @@
   <testcase classname="test" name="skipsTestTen" time="0.0">
     <skipped />
   </testcase>
+  <testcase classname="test" name="failsTestEleven" time="0.002">
+    <system-error message="expected:&lt;[world]&gt; but was:&lt;[hello]&gt;" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected:&lt;[world]&gt; but was:&lt;[hello]&gt;
+	at test.failsTestEight(Unknown Source)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+</system-error>
+  </testcase>
   <system-out><![CDATA[]]></system-out>
   <system-err><![CDATA[]]></system-err>
 </testsuite>


### PR DESCRIPTION
Add [CRASH] label when the test has failed with `system-error` tag. Otherwise these cases weren't appearing in the summary