### PR TITLE
fix: mark test when flaky in workflow

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -235,7 +235,7 @@ function isFlakyFromExecutionHistory(runCount, failCount) {
     if (!runCount || !failCount) {
         return false;
     }
-    return failCount > 0 && failCount < runCount;
+    return runCount > 0 && failCount > 0 && failCount < runCount;
 }
 function markFlakyTests(result, flakyTestsJsonPath) {
     if (flakyTestsJsonPath && !fs.existsSync(flakyTestsJsonPath)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -231,26 +231,40 @@ const fs = __importStar(__nccwpck_require__(7147));
 const core = __importStar(__nccwpck_require__(2186));
 // This is the maximum length for a VARCHAR in PostgreSQL, which is used to store test case names for flaky tests.
 const MAX_LONG_VARCHAR_LENGTH = 65535;
-function markFlakyTests(result, flakyTestsJsonPath) {
-    if (!fs.existsSync(flakyTestsJsonPath)) {
-        core.warning(`Flaky tests JSON file not found: ${flakyTestsJsonPath}`);
-        return result; // Return the original result if no flaky tests file is found
+function isFlakyFromExecutionHistory(runCount, failCount) {
+    if (!runCount || !failCount) {
+        return false;
     }
-    const data = fs.readFileSync(flakyTestsJsonPath, "utf-8");
-    const flakyTestsJson = JSON.parse(data);
-    for (const flakyTest of flakyTestsJson) {
-        const suiteName = flakyTest.testsuite;
-        const matchingSuite = result.suites.find(suite => suite.project === suiteName || suite.name === suiteName);
-        if (matchingSuite) {
-            const matchingCase = matchingSuite.cases.find(testCase => {
-                var _a;
-                return ((_a = testCase.name) === null || _a === void 0 ? void 0 : _a.slice(0, MAX_LONG_VARCHAR_LENGTH)) ===
-                    flakyTest.name &&
-                    testCase.description === flakyTest.class;
-            });
-            if (matchingCase) {
-                matchingCase.flaky = true; // Mark the case as flaky
-                matchingCase.flakyTestTicket = flakyTest.jira_ticket_url; // Set the ticket if available
+    return failCount > 0 && failCount < runCount;
+}
+function markFlakyTests(result, flakyTestsJsonPath) {
+    if (flakyTestsJsonPath && !fs.existsSync(flakyTestsJsonPath)) {
+        core.warning(`Flaky tests JSON file not found: ${flakyTestsJsonPath}`);
+    }
+    else if (flakyTestsJsonPath) {
+        const data = fs.readFileSync(flakyTestsJsonPath, "utf-8");
+        const flakyTestsJson = JSON.parse(data);
+        for (const flakyTest of flakyTestsJson) {
+            const suiteName = flakyTest.testsuite;
+            const matchingSuite = result.suites.find(suite => suite.project === suiteName || suite.name === suiteName);
+            if (matchingSuite) {
+                const matchingCase = matchingSuite.cases.find(testCase => {
+                    var _a;
+                    return ((_a = testCase.name) === null || _a === void 0 ? void 0 : _a.slice(0, MAX_LONG_VARCHAR_LENGTH)) ===
+                        flakyTest.name &&
+                        testCase.description === flakyTest.class;
+                });
+                if (matchingCase) {
+                    matchingCase.flaky = true; // Mark the case as flaky
+                    matchingCase.flakyTestTicket = flakyTest.jira_ticket_url; // Set the ticket if available
+                }
+            }
+        }
+    }
+    for (const suite of result.suites) {
+        for (const testCase of suite.cases) {
+            if (isFlakyFromExecutionHistory(testCase.run_count, testCase.fail_count)) {
+                testCase.flaky = true;
             }
         }
     }
@@ -447,13 +461,12 @@ function run() {
             /* Analyze the tests */
             let total = yield getResultsFromPaths(paths);
             /* Create and write the output */
-            if (flakyTestsJsonPath) {
-                total = (0, flaky_tests_1.markFlakyTests)(total, flakyTestsJsonPath);
-            }
+            total = (0, flaky_tests_1.markFlakyTests)(total, flakyTestsJsonPath);
+            const hasFlakyTests = total.suites.some(suite => suite.cases.some(testCase => testCase.flaky));
             let output = (0, dashboard_1.dashboardSummary)(total, show, summaryTitle, runUrl, maxSummaryLength);
             const current_length = output.length;
             if (show) {
-                output += (0, dashboard_1.dashboardResults)(total, show, flakyTestsJsonPath !== "", maxSummaryLength, current_length);
+                output += (0, dashboard_1.dashboardResults)(total, show, hasFlakyTests, maxSummaryLength, current_length);
             }
             if (outputFile === "-") {
                 core.info(output);

--- a/src/flaky_tests.ts
+++ b/src/flaky_tests.ts
@@ -6,34 +6,58 @@ import { TestResult } from "./test_parser"
 // This is the maximum length for a VARCHAR in PostgreSQL, which is used to store test case names for flaky tests.
 const MAX_LONG_VARCHAR_LENGTH = 65535
 
+function isFlakyFromExecutionHistory(
+    runCount: number | undefined,
+    failCount: number | undefined
+): boolean {
+    if (!runCount || !failCount) {
+        return false
+    }
+
+    return failCount > 0 && failCount < runCount
+}
+
 export function markFlakyTests(
     result: TestResult,
     flakyTestsJsonPath: string
 ): TestResult {
-    if (!fs.existsSync(flakyTestsJsonPath)) {
+    if (flakyTestsJsonPath && !fs.existsSync(flakyTestsJsonPath)) {
         core.warning(`Flaky tests JSON file not found: ${flakyTestsJsonPath}`)
-        return result // Return the original result if no flaky tests file is found
-    }
-    const data = fs.readFileSync(flakyTestsJsonPath, "utf-8")
-    const flakyTestsJson = JSON.parse(data)
+    } else if (flakyTestsJsonPath) {
+        const data = fs.readFileSync(flakyTestsJsonPath, "utf-8")
+        const flakyTestsJson = JSON.parse(data)
 
-    for (const flakyTest of flakyTestsJson) {
-        const suiteName = flakyTest.testsuite
+        for (const flakyTest of flakyTestsJson) {
+            const suiteName = flakyTest.testsuite
 
-        const matchingSuite = result.suites.find(
-            suite => suite.project === suiteName || suite.name === suiteName
-        )
-        if (matchingSuite) {
-            const matchingCase = matchingSuite.cases.find(
-                testCase =>
-                    testCase.name?.slice(0, MAX_LONG_VARCHAR_LENGTH) ===
-                        flakyTest.name &&
-                    testCase.description === flakyTest.class
+            const matchingSuite = result.suites.find(
+                suite => suite.project === suiteName || suite.name === suiteName
             )
+            if (matchingSuite) {
+                const matchingCase = matchingSuite.cases.find(
+                    testCase =>
+                        testCase.name?.slice(0, MAX_LONG_VARCHAR_LENGTH) ===
+                            flakyTest.name &&
+                        testCase.description === flakyTest.class
+                )
 
-            if (matchingCase) {
-                matchingCase.flaky = true // Mark the case as flaky
-                matchingCase.flakyTestTicket = flakyTest.jira_ticket_url // Set the ticket if available
+                if (matchingCase) {
+                    matchingCase.flaky = true // Mark the case as flaky
+                    matchingCase.flakyTestTicket = flakyTest.jira_ticket_url // Set the ticket if available
+                }
+            }
+        }
+    }
+
+    for (const suite of result.suites) {
+        for (const testCase of suite.cases) {
+            if (
+                isFlakyFromExecutionHistory(
+                    testCase.run_count,
+                    testCase.fail_count
+                )
+            ) {
+                testCase.flaky = true
             }
         }
     }

--- a/src/flaky_tests.ts
+++ b/src/flaky_tests.ts
@@ -14,7 +14,7 @@ function isFlakyFromExecutionHistory(
         return false
     }
 
-    return failCount > 0 && failCount < runCount
+    return runCount > 0 && failCount > 0 && failCount < runCount
 }
 
 export function markFlakyTests(

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,9 +194,10 @@ async function run(): Promise<void> {
         let total = await getResultsFromPaths(paths)
 
         /* Create and write the output */
-        if (flakyTestsJsonPath) {
-            total = markFlakyTests(total, flakyTestsJsonPath)
-        }
+        total = markFlakyTests(total, flakyTestsJsonPath)
+        const hasFlakyTests = total.suites.some(suite =>
+            suite.cases.some(testCase => testCase.flaky)
+        )
 
         let output = dashboardSummary(
             total,
@@ -211,7 +212,7 @@ async function run(): Promise<void> {
             output += dashboardResults(
                 total,
                 show,
-                flakyTestsJsonPath !== "",
+                hasFlakyTests,
                 maxSummaryLength,
                 current_length
             )

--- a/test/dashboard.ts
+++ b/test/dashboard.ts
@@ -146,6 +146,36 @@ describe("dashboard", async () => {
         expect(count).to.equal(2) // Once comes from the footer
     })
 
+    it("includes flaky marker without ticket for mixed pass/fail case", async () => {
+        const result: TestResult = {
+            counts: { passed: 1, failed: 1, skipped: 0 },
+            suites: [
+                {
+                    name: "TestSuite1",
+                    cases: [
+                        {
+                            status: TestStatus.Fail,
+                            name: "flaky-test-not-in-flaky-json",
+                            description: "test",
+                            flaky: true,
+                            run_count: 2,
+                            fail_count: 1
+                        }
+                    ]
+                }
+            ]
+        }
+
+        const actual = dashboardResults(result, TestStatus.Fail, true)
+
+        expect(actual).contains("[FLAKY]")
+        expect(actual).contains("flaky-test-not-in-flaky-json: test")
+        expect(actual).not.contains(
+            `<a href="https://jira.example.com/browse/TEST-1" target="_blank">[FLAKY]</a> `
+        )
+        expect(actual).contains("(1/2 attempts failed)")
+    })
+
     it("removes details sections to adjust to maxLength", async () => {
         const result: TestResult = {
             counts: { passed: 0, failed: 1, skipped: 0 },

--- a/test/file.ts
+++ b/test/file.ts
@@ -55,8 +55,8 @@ describe("file", async () => {
 
     it("identifies junit", async () => {
         const result = await parseFile(`${junitResourcePath}/03-junit.xml`)
-        expect(result.counts.passed).to.eql(4)
-        expect(result.counts.failed).to.eql(5)
+        expect(result.counts.passed).to.eql(5)
+        expect(result.counts.failed).to.eql(6)
         expect(result.counts.skipped).to.eql(2)
     })
 })

--- a/test/junit.ts
+++ b/test/junit.ts
@@ -95,8 +95,8 @@ describe("junit", async () => {
     it("parses junit", async () => {
         const result = await parseJunitFile(`${resourcePath}/03-junit.xml`)
 
-        expect(result.counts.passed).to.eql(4)
-        expect(result.counts.failed).to.eql(5)
+        expect(result.counts.passed).to.eql(5)
+        expect(result.counts.failed).to.eql(6)
         expect(result.counts.skipped).to.eql(2)
 
         expect(result.suites.length).to.eql(1)
@@ -211,12 +211,14 @@ describe("junit", async () => {
         expect(resultUpdated.suites[0].cases[6].flaky).to.eql(false)
         expect(resultUpdated.suites[0].cases[7].flaky).to.eql(false)
         expect(resultUpdated.suites[0].cases[8].flaky).to.eql(false)
-        expect(resultUpdated.suites[0].cases[9].flaky).to.eql(true)
-        expect(resultUpdated.suites[0].cases[9].flakyTestTicket).to.eql(
+        expect(resultUpdated.suites[0].cases[9].flaky).to.eql(false)
+        expect(resultUpdated.suites[0].cases[10].flaky).to.eql(false)
+        expect(resultUpdated.suites[0].cases[11].flaky).to.eql(true)
+        expect(resultUpdated.suites[0].cases[11].flakyTestTicket).to.eql(
             "https://jira.example.com/browse/TEST-1"
         )
-        expect(resultUpdated.suites[0].cases[10].flaky).to.eql(true)
-        expect(resultUpdated.suites[0].cases[10].flakyTestTicket).to.eql(
+        expect(resultUpdated.suites[0].cases[12].flaky).to.eql(true)
+        expect(resultUpdated.suites[0].cases[12].flakyTestTicket).to.eql(
             undefined
         )
     })

--- a/test/resources/junit/03-junit.xml
+++ b/test/resources/junit/03-junit.xml
@@ -123,7 +123,7 @@
   </testcase>
   <testcase classname="test" name="failsTestEleven" time="0.002">
     <system-err message="expected:&lt;[world]&gt; but was:&lt;[hello]&gt;" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected:&lt;[world]&gt; but was:&lt;[hello]&gt;
-	at test.failsTestEight(Unknown Source)
+	at test.failsTestEleven(Unknown Source)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
@@ -132,6 +132,18 @@
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 </system-err>
   </testcase>
+  <testcase classname="test" name="flakyTestTwelve" time="0.002">
+    <failure message="expected:&lt;[world]&gt; but was:&lt;[hello]&gt;" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected:&lt;[world]&gt; but was:&lt;[hello]&gt;
+	at test.flakyTestTwelve(Unknown Source)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+</failure>
+  </testcase>
+  <testcase classname="test" name="flakyTestTwelve" time="0.002"/>
   <system-out><![CDATA[]]></system-out>
   <system-err><![CDATA[]]></system-err>
 </testsuite>

--- a/test/results.ts
+++ b/test/results.ts
@@ -2,6 +2,7 @@ import { expect, assert } from "chai"
 
 import { TestStatus, parseJunitFile } from "../src/test_parser"
 import { getResultsFromPaths } from "../src/index"
+import { markFlakyTests } from "../src/flaky_tests"
 
 const resourcePath = `${__dirname}/resources/junit`
 
@@ -13,12 +14,24 @@ describe("results", async () => {
         ]
 
         const total = await getResultsFromPaths(paths)
-        expect(total.counts.passed).to.eql(8)
+        expect(total.counts.passed).to.eql(10)
         expect(total.suites[0].cases[0].run_count).to.eql(2)
         expect(total.suites[0].cases[0].fail_count).to.eql(0)
         expect(total.suites[0].cases[4].run_count).to.eql(2)
         expect(total.suites[0].cases[4].fail_count).to.eql(2)
         expect(total.suites[0].cases[8].run_count).to.eql(0) // Skipped tests should have run_count=0
+        expect(total.suites[0].cases[11].fail_count).to.eql(2)
+        expect(total.suites[0].cases[11].run_count).to.eql(4)
         expect(total.suites.length).to.eql(1) // There's only one suite
+    })
+
+    it("marks tests as flaky when merged runs include both pass and fail", async () => {
+        let paths = [
+            `${resourcePath}/03-junit.xml`
+        ]
+        const total = await getResultsFromPaths(paths)
+        markFlakyTests(total, "")
+        expect(total.suites[0].cases[10].flaky).to.eql(false)
+        expect(total.suites[0].cases[11].flaky).to.eql(true)
     })
 })


### PR DESCRIPTION
mark a test as flaky in the summary when has showed flakiness in the workflow even if not in the `flaky-tests.json` file.