### PR TITLE
chore: disable conventional commits for dependabot

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ jobs:
   commit-message:
     name: Conventional Commit Message Compliance
     runs-on: ubuntu-latest
-
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Run Commisery
         uses: tomtom-international/commisery-action@v3


### PR DESCRIPTION
Conventional commits is failing on every Dependabot PR related to security updates.

From [Dependabot documentation](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-security-updates):

> Note
> There is no interaction between the settings specified in the dependabot.yml file and Dependabot security alerts, other than the fact that alerts will be closed when related pull requests generated by Dependabot for security updates are merged.

So we either disable security updates or disable conventional commits for Dependabot, since the current configuration for the commits is skipped when it's a security update.

I chose disabling the check to ensure security updates don't take a month to get applied, since we are only checking dependencies monthly.